### PR TITLE
Fixes typos in documentation

### DIFF
--- a/docs/plugin-development/restrictions.md
+++ b/docs/plugin-development/restrictions.md
@@ -13,7 +13,7 @@ Please make sure that, as much as possible:
 - your plugin does not interact with the game servers in a way that is:
   - automatic, as in polling data or making requests without direct interaction
     from the user
-  - outside of specification, as in allowing the player to do submit things to
+  - outside of specification, as in allowing the player to do or submit things to
     the server that would not be possible by normal means
 - your plugin does not augment, alter, or interfere with combat, unless it only
   provides information about your own party or alliance members that is

--- a/docs/versions/index.md
+++ b/docs/versions/index.md
@@ -65,7 +65,7 @@ The more you know! ✨
 
 ## Branches & Channels
 
-Branches are channels are two different concepts, but they are closely related.
+Branches and channels are two different concepts, but they are closely related.
 Branches are the actual git branches that Dalamud is developed on, while
 Channels control the updates that users receive on their clients.
 


### PR DESCRIPTION
Hello! I was giving a first pass through of the docs and found a couple spots with typos that could be fixed. Let me know if you got any special templates or procedures for these types of changes; if I find any more things that could be fixed, I'll open other PRs like this one.