### PR TITLE
Linting: disable rule remark-lint-maximum-heading-length properly

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -6,5 +6,6 @@ module.exports = {
     'preset-prettier',
     'remark-frontmatter',
     'remark-gfm',
+    ['remark-lint-maximum-heading-length', false],
   ],
 };

--- a/docs/faq/development.mdx
+++ b/docs/faq/development.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 5
 ---
 
-{/* lint disable maximum-heading-length */}
-
 # Development
 
 ```mdx-code-block

--- a/docs/faq/reverse-engineering.mdx
+++ b/docs/faq/reverse-engineering.mdx
@@ -2,8 +2,6 @@
 sidebar_position: 6
 ---
 
-{/* lint disable maximum-heading-length */}
-
 # Reverse Engineering
 
 ```mdx-code-block

--- a/docs/plugin-development/restrictions.md
+++ b/docs/plugin-development/restrictions.md
@@ -1,5 +1,3 @@
-<!--lint disable maximum-heading-length-->
-
 # Restrictions
 
 ## What am I allowed to do in my plugin?

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "remark-frontmatter": "^4.0.1",
     "remark-gfm": "^3.0.1",
     "remark-lint": "^9.1.2",
+    "remark-lint-maximum-heading-length": "^3.1.2",
     "remark-preset-lint-consistent": "^5.1.2",
     "remark-preset-lint-markdown-style-guide": "^5.1.3",
     "remark-preset-lint-recommended": "^6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ devDependencies:
   remark-lint:
     specifier: ^9.1.2
     version: 9.1.2
+  remark-lint-maximum-heading-length:
+    specifier: ^3.1.2
+    version: 3.1.2
   remark-preset-lint-consistent:
     specifier: ^5.1.2
     version: 5.1.2
@@ -2986,6 +2989,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -2994,6 +2998,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -3002,6 +3007,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -3010,6 +3016,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 


### PR DESCRIPTION
There seems to be some weirdness regarding how plugins are disabled when different versions are being isolated by `pnpm` due to them being present in multiple rule packs:

https://github.com/remarkjs/remark-lint/issues/165#issuecomment-1604047847

Explicitly installing the rule to disable fixes the problem, allowing the rule to be disabled globally.