### PR TITLE
Reintroduce light mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -172,8 +172,8 @@ export default {
       },
       colorMode: {
         defaultMode: 'dark',
-        disableSwitch: true,
-        respectPrefersColorScheme: false,
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
       },
       algolia: {
         appId: 'FA3MQDJLPG',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,8 +6,6 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  /* light theme is disabled for now */
-  /*
   --ifm-color-primary: #2e8555;
   --ifm-color-primary-dark: #29784c;
   --ifm-color-primary-darker: #277148;
@@ -16,9 +14,8 @@
   --ifm-color-primary-lighter: #359962;
   --ifm-color-primary-lightest: #3cad6e;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-  */
+
   --ifm-code-font-size: 95%;
-  --ifm-footer-background-color: #1c0606;
   /* namespace names are long, increase the sidebar width so they don't wrap */
   --doc-sidebar-width: 450px !important;
 }
@@ -32,6 +29,7 @@
   --ifm-color-primary-light: #ffac9e;
   --ifm-color-primary-lighter: #ffb6a8;
   --ifm-color-primary-lightest: #ffe5dd;
+  --ifm-footer-background-color: #1c0606;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
Looks fine to me. Primary colour is currently a greenish, could reuse the dalamud red instead?

Pinging @avafloww, why was this disabled originally? 

![image](https://github.com/goatcorp/dalamud-docs/assets/27009727/1f0ae43d-99e7-4593-9d7f-9703dcaf0981)