### PR TITLE
Update getting-started.mdx

### DIFF
--- a/docs/faq/getting-started.mdx
+++ b/docs/faq/getting-started.mdx
@@ -40,7 +40,7 @@ customising it to your requirements. While `SamplePlugin` is the most actively
 maintained, the others are updated as required:
 
 - [@goatcorp/SamplePlugin](https://github.com/goatcorp/SamplePlugin)
-- [@karashiiro/DalamudPluginProjectTemplate](https://karashiiro/DalamudPluginProjectTemplate)
+- [@karashiiro/DalamudPluginProjectTemplate](https://github.com/karashiiro/DalamudPluginProjectTemplate)
 - [@lmcintyre/PluginTemplate](https://github.com/lmcintyre/PluginTemplate)
 
 To distribute a plugin, it needs to be packaged correctly. This can be done


### PR DESCRIPTION
correcting the link to karashiiro's github repo for DalamudPluginProjectTemplate (although it hasn't been updated in almost 2 years)