### PR TITLE
Document plugin manifests

### DIFF
--- a/docs/plugin-development/getting-started.md
+++ b/docs/plugin-development/getting-started.md
@@ -13,7 +13,8 @@ requirements. This plugin template contains many common settings as well as
 frequently-used sample code to help bootstrap plugin creation.
 
 To distribute a plugin, it needs to be packaged correctly. This can be done
-manually or [with DalamudPackager](https://github.com/goatcorp/DalamudPackager).
+manually or [with DalamudPackager](https://github.com/goatcorp/DalamudPackager)
+– see [Setting Plugin Metadata](plugin-metadata) for more details.
 
 When your plugin is ready for testing/release, you should make a pull request to
 the [DalamudPluginsD17](https://github.com/goatcorp/DalamudPluginsD17) repo.

--- a/docs/plugin-development/plugin-metadata.md
+++ b/docs/plugin-development/plugin-metadata.md
@@ -1,0 +1,75 @@
+# Setting Plugin Metadata
+
+Writing a plugin is all well and good, but you're also going to want some way to
+configure how it appears in the plugin installer: its name, description, icon,
+and so on. You do this by writing a _plugin manifest_, which is a JSON or YAML
+file named after your plugin's internal name (for example: `SamplePlugin.yaml`).
+
+:::info
+
+When using a YAML manifest, you should replace CamelCase keys with snake_case
+(for example, where a JSON manifest would contain `RepoUrl`, a YAML manifest
+would contain `repo_url`).
+
+:::
+
+## Example
+
+A very basic YAML manifest might look something like this:
+
+```yaml
+name: Test Plugin
+author: You
+punchline: Does nothing! # short summary that fits on one line
+description: |- # long description, shown when your plugin is clicked on
+  This is a test plugin - this first line is a summary.
+
+  Down here is a more detailed explanation of what the plugin
+  does, manually wrapped to make sure it stays visible in the
+  installer.
+repo_url: https://example.com # where can users find your plugin's source code?
+```
+
+## Available manifest keys
+
+These keys are required:
+
+- Name
+- Author
+- Description
+- Punchline
+
+Optional keys include:
+
+- ApplicableVersion
+- RepoUrl
+- Tags
+- CategoryTags
+- LoadRequiredState
+- LoadSync
+- CanUnloadAsync
+- LoadPriority
+- ImageUrls
+- IconUrl
+- Changelog
+- AcceptsFeedback
+- FeedbackMessage
+
+See [the DalamudPackager source][] for further information. (You may also be
+interested in [the properties Dalamud will load][], some of which are set
+automatically by the various plumbing that gets your plugins from GitHub to
+people's computers.)
+
+Note that the following keys are also required for Dalamud to load a plugin, but
+if you're using [DalamudPackager][], it will automatically fill them in for you,
+so **you can and should ignore these**:
+
+- AssemblyVersion
+- InternalName
+- DalamudApiLevel
+
+[DalamudPackager]: https://github.com/goatcorp/DalamudPackager
+[the DalamudPackager source]:
+  https://github.com/goatcorp/DalamudPackager/blob/084f66e6af7edbf8a45820590ca71765376b901c/DalamudPackager/DalamudPackager.cs#L303
+[the properties Dalamud will load]:
+  https://github.com/goatcorp/Dalamud/blob/532781308d6291a2c0117e0e73a8252358e2d91a/Dalamud/Plugin/Internal/Types/PluginManifest.cs

--- a/docs/plugin-development/plugin-metadata.md
+++ b/docs/plugin-development/plugin-metadata.md
@@ -2,8 +2,9 @@
 
 Writing a plugin is all well and good, but you're also going to want some way to
 configure how it appears in the plugin installer: its name, description, icon,
-and so on. You do this by writing a _plugin manifest_, which is a JSON or YAML
-file named after your plugin's internal name (for example: `SamplePlugin.yaml`).
+update changelogs, and so on. You do this by writing a _plugin manifest_, which
+is a JSON or YAML file named after your plugin's internal name (for example:
+`SamplePlugin.yaml`).
 
 :::info
 
@@ -51,7 +52,7 @@ Optional keys include:
 - LoadPriority
 - ImageUrls
 - IconUrl
-- Changelog
+- Changelog (see [Changelogs](#changelogs) below for alternatives)
 - AcceptsFeedback
 - FeedbackMessage
 
@@ -69,8 +70,35 @@ so **you can and should ignore these**:
 - InternalName
 - DalamudApiLevel
 
+## Changelogs
+
+You can set a plugin changelog in three separate ways:
+
+1. Include a `changelog` field in your `manifest.toml`, in the
+   [DalamudPlugins17][] repository
+2. Write text in your Pull Request description
+3. Include the `Changelog` key in your plugin manifest
+
+These will be checked in order, and the first available changelog will be used.
+
+:::warning
+
+If you'd like your changelog to be visible in the plugin installer, you must
+include it in `manifest.toml` or your plugin manifest, not the PR description.
+
+:::
+
+### Discord webhook
+
+Plugin updates are usually automatically posted in the XIVLauncher & Dalamud
+Discord server. If you'd rather write an announcement message yourself, you can
+prevent the automatic post by starting your Pull Request description with the
+word `nofranz`. Note that any changelog you write in `manifest.toml` or the
+plugin manifest will still be visible to users via the plugin installer.
+
 [DalamudPackager]: https://github.com/goatcorp/DalamudPackager
 [the relevant part of DalamudPackager]:
   https://github.com/goatcorp/DalamudPackager/blob/084f66e6af7edbf8a45820590ca71765376b901c/DalamudPackager/DalamudPackager.cs#L303
 [the definition of `IPluginManifest`]:
   https://github.com/goatcorp/Dalamud/blob/532781308d6291a2c0117e0e73a8252358e2d91a/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs#L9
+[DalamudPlugins17]: https://github.com/goatcorp/DalamudPluginsD17

--- a/docs/plugin-development/plugin-metadata.md
+++ b/docs/plugin-development/plugin-metadata.md
@@ -55,10 +55,11 @@ Optional keys include:
 - AcceptsFeedback
 - FeedbackMessage
 
-See [the DalamudPackager source][] for further information. (You may also be
-interested in [the properties Dalamud will load][], some of which are set
-automatically by the various plumbing that gets your plugins from GitHub to
-people's computers.)
+See [the definition of `IPluginManifest`][] for further information. NB: some
+fields mentioned there, like `Dip17Channel`, are set automatically by the
+various plumbing that gets your plugins from GitHub to people's computers, and
+you should not include them in your manifest explicitly. (For a list of the keys
+you're allowed to set, see [the relevant part of DalamudPackager][].)
 
 Note that the following keys are also required for Dalamud to load a plugin, but
 if you're using [DalamudPackager][], it will automatically fill them in for you,
@@ -69,7 +70,7 @@ so **you can and should ignore these**:
 - DalamudApiLevel
 
 [DalamudPackager]: https://github.com/goatcorp/DalamudPackager
-[the DalamudPackager source]:
+[the relevant part of DalamudPackager]:
   https://github.com/goatcorp/DalamudPackager/blob/084f66e6af7edbf8a45820590ca71765376b901c/DalamudPackager/DalamudPackager.cs#L303
-[the properties Dalamud will load]:
-  https://github.com/goatcorp/Dalamud/blob/532781308d6291a2c0117e0e73a8252358e2d91a/Dalamud/Plugin/Internal/Types/PluginManifest.cs
+[the definition of `IPluginManifest`]:
+  https://github.com/goatcorp/Dalamud/blob/532781308d6291a2c0117e0e73a8252358e2d91a/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs#L9

--- a/docs/plugin-development/plugin-metadata.md
+++ b/docs/plugin-development/plugin-metadata.md
@@ -35,26 +35,26 @@ repo_url: https://example.com # where can users find your plugin's source code?
 
 These keys are required:
 
-- Name
-- Author
-- Description
-- Punchline
+- `Name`
+- `Author`
+- `Description`
+- `Punchline`
 
 Optional keys include:
 
-- ApplicableVersion
-- RepoUrl
-- Tags
-- CategoryTags
-- LoadRequiredState
-- LoadSync
-- CanUnloadAsync
-- LoadPriority
-- ImageUrls
-- IconUrl
-- Changelog (see [Changelogs](#changelogs) below for alternatives)
-- AcceptsFeedback
-- FeedbackMessage
+- `ApplicableVersion`
+- `RepoUrl`
+- `Tags`
+- `CategoryTags`
+- `LoadRequiredState`
+- `LoadSync`
+- `CanUnloadAsync`
+- `LoadPriority`
+- `ImageUrls`
+- `IconUrl`
+- `Changelog` (see [Changelogs](#changelogs) below for alternatives)
+- `AcceptsFeedback`
+- `FeedbackMessage`
 
 See [the definition of `IPluginManifest`][] for further information. NB: some
 fields mentioned there, like `Dip17Channel`, are set automatically by the
@@ -75,7 +75,7 @@ so **you can and should ignore these**:
 You can set a plugin changelog in three separate ways:
 
 1. Include a `changelog` field in your `manifest.toml`, in the
-   [DalamudPlugins17][] repository
+   [DalamudPluginsD17][] repository
 2. Write text in your Pull Request description
 3. Include the `Changelog` key in your plugin manifest
 
@@ -98,7 +98,7 @@ plugin manifest will still be visible to users via the plugin installer.
 
 [DalamudPackager]: https://github.com/goatcorp/DalamudPackager
 [the relevant part of DalamudPackager]:
-  https://github.com/goatcorp/DalamudPackager/blob/084f66e6af7edbf8a45820590ca71765376b901c/DalamudPackager/DalamudPackager.cs#L303
+  https://github.com/goatcorp/DalamudPackager/blob/f199a98840389779f2398f37f08211cf66f77486/DalamudPackager/DalamudPackager.cs#L303
 [the definition of `IPluginManifest`]:
-  https://github.com/goatcorp/Dalamud/blob/532781308d6291a2c0117e0e73a8252358e2d91a/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs#L9
-[DalamudPlugins17]: https://github.com/goatcorp/DalamudPluginsD17
+  https://github.com/goatcorp/Dalamud/blob/15352a3e235a893e097e8f3e998818124a278416/Dalamud/Plugin/Internal/Types/Manifest/IPluginManifest.cs#L8
+[DalamudPluginsD17]: https://github.com/goatcorp/DalamudPluginsD17


### PR DESCRIPTION
substantially based on Franz's messages here: https://discord.com/channels/581875019861328007/860813266468732938/1212577414807429170

adjacent things that aren't included:

- how to set changelogs (from PR, from manifest.toml, from plugin manifest), incl. nofranz
- how to set icons (in dev plugins and/or via manifest.toml)

potentially this page's content as I've written it could plausibly live in the DalamudPackager readme? but the additional context about changelogs and icons, if I get round to writing it, definitely doesn't fit there

(sidenote: it looks like existing files are hard-wrapped at 80 columns but I can't see an editorconfig or similar to encourage that; I can add one if desired)