### PR TITLE
[FIX] Add branch to docfx to let it generate proper source URLs

### DIFF
--- a/ci-build.mjs
+++ b/ci-build.mjs
@@ -120,7 +120,14 @@ for (const branch of Object.keys(versions)) {
   }
 
   // generate metadata
-  exec('docfx metadata', { cwd: branchDir, ...execOptions });
+  exec('docfx metadata', { 
+    cwd: branchDir,
+    env: {
+      'DOCFX_SOURCE_BRANCH_NAME': branch,
+      ...process.env,
+    },
+    ...execOptions 
+  });
 
   // execute dfmg
   exec('dfmg', {


### PR DESCRIPTION
Looking at https://github.com/dotnet/docfx/blob/cb7c9c82ca2bab664e22c6047e8147627ca27129/src/Docfx.Common/Git/GitUtility.cs#L20, it seems that docfx doesn't automatically infer the active git branch from its content directory, but rather from currently set environment variables.

This fix makes sure to set the `DOCFX_SOURCE_BRANCH_NAME` to the current branch in the iteration, so source URL's are generated properly in the output metadata.

