### PR TITLE
Add information about interface changes + marketboard

### DIFF
--- a/docs/versions/v10.md
+++ b/docs/versions/v10.md
@@ -23,7 +23,15 @@ all of these changes
 
 ## New Features
 
+- Added `IMarketBoard`, which exposes market events that Dalamud already had implemented to provide Universalis with it's pricing data. This will allow users to subscribe to these events without having to hook those events themselves. 
+
 ## Major Changes
+
+- There has been refactoring in relation to what interfaces/classes Dalamud provides. Generally speaking Dalamud will now provide interfaces where possible. This should make it easier for plugins to unit test/mock as required.
+  - The majority of public facing classes provided by dalamud services to plugins have been interfaced. 
+  - `DalamudPluginInterface` is now `IDalamudPluginInterface`, you must request a `IDalamudPluginInterface` in your plugin's constructor.
+  - `UiBuilder` is now `IUiBuilder`
+  - For a full list please see [Interface Changes](#interface-changes)
 
 ## Minor Changes
 
@@ -36,8 +44,32 @@ These changes have been made after the official stabilization.
 We want to thank the following people for their contributions to Dalamud during
 this patch cycle:
 
-## FFXIVClientStructs changes
+## FFXIVClientStructs Changes
 
 These are relevant changes made to FFXIVClientStructs, listed here for
 reference. We want to thank aers, Pohky, WildWolf and the other
 FFXIVClientStructs contributors for their work.
+                                                            
+## Class/Interface Changes
+- DalamudPluginInterface -> IDalamudPluginInterface
+- UiBuilder -> IUiBuilder
+- AetheryteEntry -> IAetheryteEntry
+- AetheryteList -> IAetheryteList
+- BuddyMember -> IBuddyMember
+- BuddyList -> IBuddyList
+- GameObject -> IGameObject
+- PlayerCharacter -> IPlayerCharacter
+- BattleChara -> IBattleChara
+- BattleNpc -> IBattleNpc
+- Character -> ICharacter
+- Fate -> IFate
+- PartyMember -> IPartyMember
+- CommandInfo -> IReadOnlyCommandInfo
+- MenuItem -> IMenuItem
+- MenuArgs -> IMenuArgs
+- MenuItemClickedArgs -> IMenuItemClickedArgs
+- MenuOpenedArgs -> IMenuOpenedArgs
+- DtrBarEntry -> IDtrBarEntry
+- PartyFinderListing -> IPartyFinderListing
+- PartyFinderListingEventArgs -> IPartyFinderListingEventArgs
+- TitleScreenMenuEntry -> ITitleScreenMenuEntry and IReadOnlyTitleScreenMenuEntry


### PR DESCRIPTION
Let me know if you need less/more. Tried to keep what was mentioned in Major Changes limited to what everyone will need to know then put a link to the class -> interface list. I figure this might be important as not all the classes moved from ClassName to IClassName, some are ClassName to IReadOnlyClassName