### PR TITLE
Link Typo Fix in "What's New in Dalamud v10"

### DIFF
--- a/docs/versions/v10.md
+++ b/docs/versions/v10.md
@@ -32,7 +32,7 @@ all of these changes
   - The majority of public facing classes provided by dalamud services to plugins have been interfaced. 
   - `DalamudPluginInterface` is now `IDalamudPluginInterface`, you must request a `IDalamudPluginInterface` in your plugin's constructor.
   - `UiBuilder` is now `IUiBuilder`
-  - For a full list please see [Interface Changes](#interface-changes)
+  - For a full list please see [Class/Interface Changes](#classinterface-changes)
  
 - `ITextureProvider` has been reworked to be more performant and easier to use.
   - All of the functions inside now return a `ISharedImmediateTexture`, instead of a texture wrap. This represents an instance of a texture that may or may not be loaded yet. All textures are loaded asynchronously to avoid making the game hitch.


### PR DESCRIPTION
Change link to `#classinterface-changes` to properly link to the changes list at the bottom of the page.