### PR TITLE
v12: add note about GameInventoryItem.ItemId not removing offsets anymore

### DIFF
--- a/docs/versions/v12.md
+++ b/docs/versions/v12.md
@@ -52,6 +52,8 @@ distribute SDK files in the future.
 - All job gauge enum values have been converted from SNAKE_CASE to PascalCase to follow C# code standards.
 - The `Easing#Value` property has been deprecated. Devs should select either `ValueClamped` or `ValueUnclamped` depending on their use case.
 - `PluginLoadReason` is now a `[Flags]` enum. Use `.HasFlag()` to check its values.
+- `GameInventoryItem.ItemId` now returns the ID of the item with offsets (like Collectable, HQ, etc.) applied.
+  - `GameInventoryItem.BaseItemId` is now the base ID of the item without flags.
 
 ## Packages
 


### PR DESCRIPTION
This document changes made there: https://github.com/goatcorp/Dalamud/pull/2219/files#diff-034c2ab63a63c80f86945604c97eea6827456e0c80491a9e59b9710659c5c788L51