### PR TITLE
Update v13 docs

### DIFF
--- a/docs/versions/v13.md
+++ b/docs/versions/v13.md
@@ -26,17 +26,6 @@ SDK files in the future.
 
 :::
 
-## New Features
-
-- DTR Bar events now contain information about which mouse button was clicked
-- New ClientStructs-independent wrapper structs have been introduced for
-  AtkUnitBase, AgentInterface and UIModule. Due to time constraints these
-  currently only provide very basic (or in the case of UIModule no)
-  functionality. They have `IsNull` and `Address` properties and are implicitly
-  castable to `nint`. You're free to cast the Address field to another pointer
-  type. These wrappers are used in `IGameGui` and in the `AddonArgs` of
-  `IAddonLifecycle.`
-
 ## Major Changes
 
 - Dalamud uses new bindings to the ImGui UI library, derived from
@@ -67,22 +56,71 @@ SDK files in the future.
   - Capitalization of enum names is now in PascalCase, for example
     `ImGuiColorEditFlags.DisplayRGB` is now `ImGuiColorEditFlags.DisplayRgb`.
   - Functions that had `out` parameters now take those via pointer or `ref`.
-- `IGameNetwork`: The service was removed, as opcodes change every patch, making
-  maintenance arduous, and the packet data itself has proven itself to be very
-  unreliable.
-  - Please hook functions that process the data instead - reach out on Discord
-    if you are having issues with this, as doing this can be quite
-    feature-specific.
-- `IDalamudPluginInterface.AddChatLinkHandler`, and `RemoveChatLinkHandler` have
-  been moved to the `IChatGui` service.
+- New ClientStructs-independent wrapper structs have been introduced for
+  AtkUnitBase, AgentInterface and UIModule. Due to time constraints these
+  currently only provide very basic (or in the case of UIModule no)
+  functionality. They have `IsNull` and `Address` properties and are implicitly
+  castable to `nint`. You're free to cast the Address field to another pointer
+  type.
+
+### IGameNetwork
+
+The service was removed, as opcodes change every patch, making maintenance
+arduous, and the packet data itself has proven itself to be very unreliable.
+
+- Please hook functions that process the data instead - reach out on Discord if
+  you are having issues with this, as doing this can be quite feature-specific.
+
+### IAddonLifecycle
+
+- `AddonArgs.Addon` is now of type `AtkUnitBasePtr`.
+
+### IDalamudPluginInterface
+
+- `AddChatLinkHandler`, and `RemoveChatLinkHandler` have been moved to the
+  `IChatGui` service.
+- `ActivePluginsChanged` is now called when a plugin loaded (with
+  `PluginListInvalidationKind.Loaded`) or unloaded (with
+  `PluginListInvalidationKind.Unloaded`).
+  - Please note that enabling or disabling collections will trigger individual
+    events for each plugin.
+
+### IDtrBar
+
+- `IReadOnlyDtrBarEntry.OnClick` now receives an `AddonMouseEventData`
+  parameter.
+  - `AddonMouseEventData` contains the following properties: `IsLeftClick`,
+    `IsRightClick`, `IsNoModifier`, `IsAltHeld`, `IsControlHeld`, `IsShiftHeld`,
+    `IsDragging`, `IsScrollUp`, `IsScrollDown`, `Position`.
+- `IReadOnlyDtrBarEntry.TriggerClickAction` has been removed due to changes to
+  `OnClick`.
+
+### IGameGui
+
+- `GetUIModule` now returns `UIModulePtr`.
+- `GetAddonByName` now returns `AtkUnitBasePtr`.
+- `GetAgentById` and the two `FindAgentInterface` functions now return
+  `AgentInterfacePtr`.
+
+### IObjectTable
+
+- New enumerables have been added: `PlayerObjects`, `CharacterManagerObjects`,
+  `ClientObjects`, `EventObjects`, `StandObjects` and `ReactionEventObjects`.
+
+### IUiBuilder
+
+- New events have been added: `DefaultGlobalScaleChanged`, `DefaultFontChanged`
+  and `DefaultStyleChanged`.
+- New properties have been added: `FontDefaultSizePt`, `FontDefaultSizePx`,
+  `FontDefault`, `FontIcon`, `FontMono`.
 
 ## Minor Changes
 
 - `Dalamud.Game.Text.SeStringHandling.Payloads.ItemPayload.ItemKind` was moved
   out of the ItemPayload, to the `Dalamud.Utility` namespace.
 - `ISeStringEvaluator`: The service is no longer experimental and now supports
-  the SheetSub payload.  
-  Note: A new payload was found in 7.3, which will be supported at a later time.
+  the SheetSub payload.
+  - A new payload was found in 7.3, which will be supported at a later time.
 - Lumina: The `ExtractText()` function on ReadOnlySeString and
   ReadOnlySeStringSpan does no longer need to be called. The `ToString()`
   function now returns text only (without soft hyphens!) and optionally provides


### PR DESCRIPTION
Added sections for each affected service and added some more changes.

Btw, the `:::warning\[Dalamud.NET.Sdk Migration]` doesn't work because it's escaped. The formatter automatically does that when I commit. Maybe it's not supported by our docusaurus version.