### PR TITLE
Fix broken links to plugin restrictions documentation

### DIFF
--- a/docs/faq/getting-started.mdx
+++ b/docs/faq/getting-started.mdx
@@ -30,10 +30,10 @@ use another IDE such as [JetBrains Rider](https://www.jetbrains.com/rider/).
 
 Plugins allow you to interact with the game and add features, modify
 functionality, and do much more. We ask you to be respectful of
-[our guidelines](../plugin-development/restrictions.md#what-am-i-allowed-to-do-in-my-plugin)
+[our guidelines](../plugin-publishing/restrictions#what-am-i-allowed-to-do-in-my-plugin)
 to ensure that your plugin is approved into the primary repository, and to
 minimise the risk of action by Square Enix. You can read more about this
-[here](../plugin-development/restrictions.md#why-do-you-discourage-certain-types-of-plugins).
+[here](../plugin-publishing/restrictions#why-do-you-discourage-certain-types-of-plugins).
 
 We recommend that you start by cloning one of the following templates, and then
 customising it to your requirements. While `SamplePlugin` is the most actively

--- a/docs/faq/reverse-engineering.mdx
+++ b/docs/faq/reverse-engineering.mdx
@@ -28,7 +28,7 @@ your best bet is the
 [Sapphire project](https://github.com/SapphireServer/Sapphire). The Dalamud
 project generally strays away from interfering with client-server communication
 for the reasons outlined in
-[What am I allowed to do in my plugin?](../plugin-development/restrictions.md#what-am-i-allowed-to-do-in-my-plugin),
+[What am I allowed to do in my plugin?](../plugin-publishing/restrictions#what-am-i-allowed-to-do-in-my-plugin),
 but understanding the flow may help with other things.
 
 Otherwise, you'll be reverse-engineering the game client, as that's what Dalamud


### PR DESCRIPTION
- Update links in getting-started.mdx and reverse-engineering.mdx
- Change from ../plugin-development/restrictions.md to ../plugin-publishing/restrictions
- Fixes issue #2380