### PR TITLE
Add Code of Conduct and AI policy

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,0 +1,170 @@
+---
+sidebar_position: 1.5
+---
+
+# Code of Conduct
+
+This Code of Conduct applies to all XIVLauncher & Dalamud community spaces,
+including our Discord server, GitHub repositories, and any venue in which
+members represent the community.
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the
+dignity, rights, and contributions of all individuals, regardless of
+characteristics including race, ethnicity, caste, color, age, physical
+characteristics, neurodiversity, disability, sex or gender, gender identity or
+expression, sexual orientation, language, philosophy or religion, national or
+social origin, socio-economic position, level of education, or other status. The
+same privileges of participation are extended to everyone who participates in
+good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our
+community's expectations for positive behavior. We also understand that our
+words and actions may be interpreted differently than we intend based on
+culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each
+other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of
+   gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our
+   community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances,
+threats, and promotion of these behaviors are violations of this Code of
+Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in
+   unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments
+   directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or
+   behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered
+   inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or
+   private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm
+   toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or
+   pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content
+   you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a
+   way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which
+   includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their
+best to collaborate. Not every conflict represents a code of conduct violation,
+and this Code of Conduct reinforces encouraged behaviors and norms that can help
+avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a
+possible violation, **please contact a member of the @moderator group
+[on our Discord server](https://discord.gg/holdshift) or send an email
+containing the details to <goatsdev@protonmail.com>.**
+
+Community Moderators take reports of violations seriously and will make every
+effort to respond in a timely manner. They will investigate all reports of code
+of conduct violations, reviewing messages, logs, and recordings, or interviewing
+witnesses and other participants. Community Moderators will keep investigation
+and enforcement actions as transparent as possible while prioritizing safety and
+confidentiality. In order to honor these values, enforcement actions are carried
+out in private with the involved parties, but communicating to the whole
+community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct
+has been violated, the following enforcement ladder may be used to determine how
+best to repair harm, based on the incident's impact on the individuals involved
+and the community as a whole. Depending on the severity of a violation, lower
+rungs on the ladder may be skipped.
+
+1. Warning
+   1. Event: A violation involving a single incident or series of incidents.
+   2. Consequence: A private, written warning from the Community Moderators.
+   3. Repair: Examples of repair include a private written apology,
+      acknowledgement of responsibility, and seeking clarification on
+      expectations.
+2. Temporarily Limited Activities
+   1. Event: A repeated incidence of a violation that previously resulted in a
+      warning, or the first incidence of a more serious violation.
+   2. Consequence: A private, written warning with a time-limited cooldown
+      period designed to underscore the seriousness of the situation and give
+      the community members involved time to process the incident. The cooldown
+      period may be limited to particular communication channels or interactions
+      with particular community members.
+   3. Repair: Examples of repair may include making an apology, using the
+      cooldown period to reflect on actions and impact, and being thoughtful
+      about re-entering community spaces after the period is over.
+3. Temporary Suspension
+   1. Event: A pattern of repeated violation which the Community Moderators have
+      tried to address with warnings, or a single serious violation.
+   2. Consequence: A private written warning with conditions for return from
+      suspension. In general, temporary suspensions give the person being
+      suspended time to reflect upon their behavior and possible corrective
+      actions.
+   3. Repair: Examples of repair include respecting the spirit of the
+      suspension, meeting the specified conditions for return, and being
+      thoughtful about how to reintegrate with the community when the suspension
+      is lifted.
+4. Permanent Ban
+   1. Event: A pattern of repeated code of conduct violations that other steps
+      on the ladder have failed to resolve, or a violation so serious that the
+      Community Moderators determine there is no way to keep the community safe
+      with this person as a member.
+   2. Consequence: Access to all community spaces, tools, and communication
+      channels is removed. In general, permanent bans should be rarely used,
+      should have strong reasoning behind them, and should only be resorted to
+      if working through other remedies has failed to change the behavior.
+   3. Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the
+ability of Community Managers to use their discretion and judgment, in keeping
+with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public or other
+spaces. Examples of representing our community include using an official email
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0,
+permanently available at <https://www.contributor-covenant.org/version/3/0/>.
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and
+licensed under CC BY-SA 4.0. To view a copy of this license, visit
+<https://creativecommons.org/licenses/by-sa/4.0/>
+
+For answers to common questions about Contributor Covenant, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are provided at
+<https://www.contributor-covenant.org/translations>. Additional enforcement and
+community guideline resources can be found at
+<https://www.contributor-covenant.org/resources>. The enforcement ladder was
+inspired by the work of
+[Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,10 +13,18 @@ Welcome to the Dalamud developer documentation!
   [Building Dalamud](/building) section.
 - If you want to learn how to get started with plugin development, check out the
   [Plugin Development](/category/plugin-development) section.
+- If you plan to submit a plugin to the official repository, review the
+  [AI Usage Policy](/plugin-publishing/ai-policy) before you start.
 - If you want to learn more about the current status of Dalamud and recent
   changes, check out the [News](/news) section.
 - If you just want raw API docs, you can [go here](/api). Core Dalamud APIs are
   fully documented!
+
+## Community
+
+All XIVLauncher & Dalamud community spaces - including our Discord server and
+GitHub repositories - are governed by our [Code of Conduct](/code-of-conduct).
+Please read it before participating.
 
 ## Contributing
 

--- a/docs/plugin-development/getting-started.md
+++ b/docs/plugin-development/getting-started.md
@@ -11,6 +11,19 @@ plugin is approved into the official plugin repository, and to minimise the risk
 of action by Square Enix. You can read more about this
 [here](../plugin-publishing/approval-process.md).
 
+:::info
+
+Before you start, please also review:
+
+- The [AI Usage Policy](../plugin-publishing/ai-policy.md), which governs the
+  use of AI tooling in plugins submitted to the official repository. Entirely
+  AI-generated submissions are not accepted, and undisclosed AI use may result
+  in a ban.
+- Our [Code of Conduct](../code-of-conduct.md), which applies to all community
+  spaces including Discord and our GitHub repositories.
+
+:::
+
 We recommend that you start by cloning the [`SamplePlugin`
 repository][sample-plugin] and then customizing it to your specific
 requirements. This plugin template contains many common settings as well as

--- a/docs/plugin-publishing/ai-policy.md
+++ b/docs/plugin-publishing/ai-policy.md
@@ -1,0 +1,124 @@
+# AI Usage Policy
+
+This policy applies to all who are considering submitting a plugin to the
+**official Dalamud plugin repository, hosted at
+[goatcorp/DalamudPluginsD17](https://github.com/goatcorp/DalamudPluginsD17/).**
+
+It **does not apply to contributions to XIVLauncher/Dalamud codebases.**
+
+_This policy may be revised as AI tooling and community standards evolve.
+Significant changes will be communicated ahead of time._
+
+## TL;DR
+
+Use AI if it helps, but you must understand, test, and be able to explain your
+code. Disclose your level of AI use. Entirely AI-generated submissions will be
+auto-rejected; undisclosed AI use or repeated violations will result in a ban.
+
+## Purpose
+
+This policy establishes guidelines for the acceptable use of AI tools in the
+development and distribution of Dalamud plugins. Our goal is to ensure plugin
+quality, maintainability, and transparency while acknowledging that AI
+assistance tools are a part of some modern development workflows.
+
+**Our intent:** We want contributors who are invested in their plugins and in
+being meaningful members of the community. If you have no investment in your
+work, we won't have any investment in reviewing it.
+
+_This policy was inspired by
+[Zulip's AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines)._
+
+## Code
+
+**Core Principle:** Code produced with AI assistance is held to the same
+standard as code written by hand. How you produce your code is up to you; what
+matters is that you can stand behind it.
+
+**Disclosure:** If AI was used at any point beyond basic autocomplete, disclose
+the level of AI involvement in your pull request description. We use the
+following levels, adapted from [AI-DECLARATION.md](https://ai-declaration.md/):
+
+- **None:** No AI tools were used at any point. _You do not need to disclose
+  this level._
+- **Hint:** AI autocomplete or inline suggestions only. The human writes all
+  code; AI occasionally completes a line or block. _You do not need to disclose
+  this level._
+- **Assist:** Human-led. AI is used on demand for specific tasks (generating a
+  function, explaining code, drafting a test) but does not drive the work.
+- **Pair:** Active human-AI collaboration throughout. Contribution is roughly
+  equal.
+- **Copilot:** AI implements while the human plans and reviews. The human
+  defines what to build and validates the output, but the AI does most of the
+  writing.
+- **Auto:** AI acts autonomously with minimal human direction. The human may
+  steer at a high level or approve outcomes, but does not write or closely
+  direct the code.
+
+If you did not use AI, or only used basic autocomplete/inline suggestions, you
+do not need to disclose anything.
+
+**Requirements:**
+
+- Personally test your plugin before submission
+- The answer to "Why did you implement it this way?" should never be "I'm not
+  sure, the AI did it"
+- Verify AI output - it frequently gets Dalamud and adjacent APIs wrong
+- Be respectful and receptive to feedback - we don't judge, but we have a duty
+  to our users and want to maintain a level of quality
+
+**Enforcement:**
+
+- **Entirely AI-generated plugins** with no meaningful human involvement will be
+  auto-rejected. Doing this twice will result in a ban.
+- **Undisclosed AI use** in a demonstrably AI-written submission will result in
+  a ban.
+- **Fixable issues:** If your submission shows AI-generated mistakes but clear
+  human intent, we'll close it with an opportunity to fix and resubmit.
+
+Our review time is limited. Please don't waste it.
+
+## Assets (Icons, Images, Music, Sounds, Textures)
+
+**Core Principle:** AI-generated assets are significantly more visible and
+contentious than code - users interact with them directly, and community
+sentiment towards AI-generated content is often negative. Be prepared for this.
+
+**For plugin icons specifically,** we want to encourage you to put together a
+hand-made icon for the plugin installer and may ask you personally to do so.
+When in doubt, we prefer a crude MS Paint icon over an AI-generated icon; the
+former is more in line with our community's values. Feel free to reach out on
+our Discord, someone will be happy to make one for you!
+
+**Requirements:**
+
+- Disclose any AI-generated assets in your plugin's description - unlike code,
+  assets are user-facing, so users should be informed
+- AI-generated audio (music, sounds) should be toggle-able or replaceable by
+  user selections where possible
+
+**Enforcement:** The same enforcement rules apply as for code. Undisclosed
+AI-generated assets in a submission will be treated the same as undisclosed
+AI-generated code.
+
+## Translations
+
+AI-assisted translations are acceptable, particularly as placeholders. However,
+be aware that AI translations cannot always capture the nuance of the original
+text without sufficient context - this is especially true in jargon-laden
+contexts like games, where terminology may have specific established meanings.
+We encourage developers to:
+
+- Consult with native speakers wherever possible to catch mistranslations or
+  awkward phrasing
+- Seek community translators for final localization
+- Use platforms like Crowdin, which support AI assistance with human review
+- Accept corrections from native speakers
+
+## Questions?
+
+Please join our [Discord server](https://discord.gg/holdshift) if you have any
+questions before or during development. We have a developer role that provides
+access to developer-oriented channels.
+
+Alternatively, feel free to ask through a comment on the PR for your plugin.

--- a/docs/plugin-publishing/index.md
+++ b/docs/plugin-publishing/index.md
@@ -1,1 +1,19 @@
 # Publishing Your Plugin
+
+This section covers everything you need to know about publishing a plugin to the
+official Dalamud plugin repository, as well as running your own custom
+repository.
+
+Before submitting, please make sure you are familiar with:
+
+- The [Plugin Restrictions](./restrictions.md), which describe what plugins are
+  and are not allowed to do.
+- The [Approval Process](./approval-process.md), which explains how plugins are
+  reviewed.
+- The [AI Usage Policy](./ai-policy.md), which covers the use of AI tools in
+  plugin code, assets, and translations. Entirely AI-generated submissions will
+  be rejected, and undisclosed AI use may result in a ban.
+- The [Submission Process](./submission.md), which walks through the mechanics
+  of opening a PR against [DalamudPluginsD17][d17].
+
+[d17]: https://github.com/goatcorp/DalamudPluginsD17

--- a/docs/plugin-publishing/submission.md
+++ b/docs/plugin-publishing/submission.md
@@ -15,6 +15,8 @@ Before submitting your plugin, make sure you have:
    [technical considerations](../../plugin-development/technical-considerations)
    for your plugin
 3. Ensured your plugin meets all [restrictions](../restrictions)
+4. Read the [AI Usage Policy](./ai-policy) and, if applicable, disclosed your
+   level of AI use in your pull request description
 
 :::
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -143,6 +143,19 @@ export default {
                 label: 'Discord',
                 href: 'https://discord.gg/holdshift',
               },
+              {
+                label: 'Code of Conduct',
+                to: '/code-of-conduct',
+              },
+            ],
+          },
+          {
+            title: 'Publishing',
+            items: [
+              {
+                label: 'AI Usage Policy',
+                to: '/plugin-publishing/ai-policy',
+              },
             ],
           },
           {


### PR DESCRIPTION
Ports these over from the governance repository and adds cross-links. Will need to add cross-links from DalamudPluginsD17 and SamplePlugin, too.