### PR TITLE
Update v15 for font changes.md

### DIFF
--- a/docs/versions/v15.md
+++ b/docs/versions/v15.md
@@ -172,6 +172,8 @@ API version.
 * 32-bit functions and attributes have been removed from `BaseAddressResolver` and `ISigScanner`
 * `IPartyMember.ContentId` is now `ulong`
 * `IClientState.LocalPlayer` and `IClientState.LocalContentId` have been removed in favor of equivalent attributes in `IPlayerState`
+* `NotoSansKrRegular` has been renamed to `NotoSansCjkRegular`
+* `NotoSansJpMedium` has been renamed to `NotoSansCjkMedium`
 
 ## Known Issues
 None yet.

--- a/docs/versions/v15.md
+++ b/docs/versions/v15.md
@@ -102,6 +102,24 @@ New additions:
 
 ## Minor Changes
 
+### Dalamud Font Assets 
+
+- `NotoSansKrRegular` has been renamed to `NotoSansCjkRegular`
+- `NotoSansJpMedium` has been renamed to `NotoSansCjkMedium`
+
+Additonally, the new `ttc` format requires the specification of 
+the requested language type, which has been added as `FontNo` to `IFontSpec`
+
+```cs
+/// The index corresponds to the font face order in the TTC:
+/// <list type="bullet">
+///   <item><description>0 = Japanese</description></item>
+///   <item><description>1 = Traditional Chinese</description></item>
+///   <item><description>2 = Simplified Chinese</description></item>
+///   <item><description>3 = Korean</description></item>
+/// </list>
+```
+
 ### New Features
 
 #### IAgentLifecycle
@@ -172,8 +190,6 @@ API version.
 * 32-bit functions and attributes have been removed from `BaseAddressResolver` and `ISigScanner`
 * `IPartyMember.ContentId` is now `ulong`
 * `IClientState.LocalPlayer` and `IClientState.LocalContentId` have been removed in favor of equivalent attributes in `IPlayerState`
-* `NotoSansKrRegular` has been renamed to `NotoSansCjkRegular`
-* `NotoSansJpMedium` has been renamed to `NotoSansCjkMedium`
 
 ## Known Issues
 None yet.


### PR DESCRIPTION
Describe the new requirements for the `ttc` format that is used for CJK font assets